### PR TITLE
Use URNs for configuration XSD paths

### DIFF
--- a/src/etc/acl.xml
+++ b/src/etc/acl.xml
@@ -33,7 +33,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Acl/etc/acl.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -34,7 +34,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../Magento/Config/etc/system_file.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="carriers">
             <group id="shipper" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1"

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -33,7 +33,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Magento/Store/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <carriers>
             <shipper>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -33,7 +33,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="ShipperHQ_Shipper" setup_version="1.0.1" >
         <sequence>
             <module name="Magento_Config"/>


### PR DESCRIPTION
[URNs](http://devdocs.magento.com/guides/v2.0/extension-dev-guide/build/XSD-XML-validation.html) for XSD declaration is recommended as installing Magneto [via composer](http://devdocs.magento.com/guides/v2.0/install-gde/prereq/integrator_install.html) will place Magento core in the `vendor` directory not at these relative paths. 