### PR TITLE
Bug: Shipping rate's carrier group shipping details are null

### DIFF
--- a/src/Plugin/Checkout/ShippingInformationPlugin.php
+++ b/src/Plugin/Checkout/ShippingInformationPlugin.php
@@ -95,7 +95,7 @@ class ShippingInformationPlugin
     {
 
         $foundRate = $shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod());
-        if($foundRate) {
+        if($foundRate && $foundRate->getCarriergroupShippingDetails()) {
             $shipDetails = $this->shipperDataHelper->decodeShippingDetails($foundRate->getCarriergroupShippingDetails());
             if(array_key_exists('carrierGroupId', $shipDetails)) {
                 $arrayofShipDetails = array();


### PR DESCRIPTION
Fix bug where $foundRate->getCarriergroupShippingDetails() returns null, and this null was being pass on to $this->shipperDataHelper->decodeShippingDetails function which was causing a fatal error because it couldn't decode null, stopping the consumer from checking out.

The default Magneto's shipping method "free shipping" was selected in the checkout and next was clicked :

![screen shot 2016-06-02 at 18 12 17 1](https://cloud.githubusercontent.com/assets/8201815/15772942/0bc716a8-296c-11e6-9619-27427baf0281.png)

I am not sure why Magneto's default shipping rate returns null when getCarriergroupShippingDetails is call on it but I think the module-shipper code should check if the return value is not what it expects and act accordingly. That is why I think this PR is needed.

Here is a copy of the error being thrown deeper in the stack :
```
[2016-06-03 07:34:39] main.CRITICAL: Zend_Json_Exception: Report ID: webapi-5751330f6a116; Message: Decoding failed: Syntax error in /project-root/vendor/magento/framework/Webapi/ErrorProcessor.php:194
```