### PR TITLE
use single single quotes in sql

### DIFF
--- a/src/Plugin/Order/CollectionFactory.php
+++ b/src/Plugin/Order/CollectionFactory.php
@@ -62,7 +62,7 @@ class CollectionFactory
                 $select = $result->getSelect();
                 $select->joinLeft(
                     ['shipper_order_join' => $this->_resource->getTableName('shipperhq_order_detail_grid')],
-                    'entity_id' . '=shipper_order_join.' . 'order_id' ,
+                    'entity_id' . '=\'shipper_order_join.' . 'order_id\'' ,
                     []
                 );
             }


### PR DESCRIPTION
without the the single, mysql won't search against the index.

When we did this we saw savings of up to 5-6 seconds in New Relic

![NR Graph](https://d1zjcuqflbd5k.cloudfront.net/files/acc_674/7LAo?response-content-disposition=inline;%20filename=Screen%20Shot%202016-11-22%20at%201.13.13%20PM.png&Expires=1479849627&Signature=KKI8kXICAC9ACayJ7MsuEoF3OhHoqoZr~5fNYIeMvjMa-g1Caa6-3mZtHGz8c-EPPmuSlWW5m7yaET2DNhLpE3Vghf6lXynoqSY07PkS3fMf-RL0SXUAA4lR-ZuSgDdkIJM2EfPeo8mHLrBzpr3t5kIoIOoZ7q5KFhnApK00OBM_&Key-Pair-Id=APKAJTEIOJM3LSMN33SA)

The query went from 17 seconds 

![query1](https://d1zjcuqflbd5k.cloudfront.net/files/acc_674/1hBbA?response-content-disposition=inline;%20filename=Screen%20Shot%202016-11-22%20at%2012.36.06%20AM.png&Expires=1479849709&Signature=Pb-VElG6zN~2ICLZvUnR9y-4DzQI5GBiEiFBGCq4CJZADaFEpbQO~YnTmxql2PRSm~n0dehF~LH4sQ628nEw7dXFkjI4HIC2RFvhZytQPj3jEddpgRde8eXkU25xwsNfbt0C7vUAP8sgnhaWzTEU0prnU8A9gkSED1dhqYFuiMk_&Key-Pair-Id=APKAJTEIOJM3LSMN33SA)

To 11 seconds

![query2](https://d1zjcuqflbd5k.cloudfront.net/files/acc_674/OCvG?response-content-disposition=inline;%20filename=Screen%20Shot%202016-11-22%20at%201.14.29%20PM.png&Expires=1479849744&Signature=bGYOT4-SrkYfC~47pU1sQehlCPPg8iR~bT4k9H5YAyZjXsVsaNN331aOJaB-HOXwW7PZIHbyaZU46OD5-TBGvBSKzoqW7kNsYGwnBGL34XMxzQaMPIucEfmXqH8XQtVrqtJByEpm2uWcEclJIrrlxz5huDVTFk7o9xvZSRRgabM_&Key-Pair-Id=APKAJTEIOJM3LSMN33SA)

image links:
https://d.pr/7LAo
https://d.pr/1hBbA
https://d.pr/OCvG