### PR TITLE
Ensure we check for the array key existing instead of assuming it is …

### DIFF
--- a/src/view/adminhtml/templates/order/view/shq_info.phtml
+++ b/src/view/adminhtml/templates/order/view/shq_info.phtml
@@ -32,49 +32,37 @@
         <?php endif; ?>
         <?php foreach($cgInfo as $carrierGroup): ?>
             <div class="order-shipping-additional">
-                <?php if($carrierGroup['pickup_location'] != ''): ?>
+                <?php if(array_key_exists('pickup_location', $carrierGroup) && $carrierGroup['pickup_location'] != ''): ?>
                     <?php echo __('Location') .': ' .$block->escapeHtml($carrierGroup['pickup_location']) ?>
                     <br/>
                 <?php endif; ?>
-                <?php if($carrierGroup['delivery_date'] != ''): ?>
+                <?php if(array_key_exists('delivery_date', $carrierGroup) && $carrierGroup['delivery_date'] != ''): ?>
                     <?php echo __('Delivery date') .': ' .$block->escapeHtml($block->getFormattedDate($carrierGroup['delivery_date'], $carrierGroup['carrier_group_detail'])) ?>
                 <?php endif; ?>
-                <?php if($carrierGroup['dispatch_date'] != ''): ?>
+                <?php if(array_key_exists('dispatch_date', $carrierGroup) && $carrierGroup['dispatch_date'] != ''): ?>
                     <br/>
                     <?php echo __('Dispatch date') .': ' .$block->escapeHtml($block->getFormattedDate($carrierGroup['dispatch_date'], $carrierGroup['carrier_group_detail'])) ?>
                 <?php endif; ?>
-                <?php if($carrierGroup['time_slot'] != ''): ?>
+                <?php if(array_key_exists('time_slot', $carrierGroup) && $carrierGroup['time_slot'] != ''): ?>
                     <br/>
                     <?php echo __('Time slot') .': ' .$block->escapeHtml($block->getFormattedTimeSlot($carrierGroup['time_slot'])) ?>
                 <?php endif; ?>
-                <?php if($carrierGroup['liftgate_required'] === '1'): ?>
+                <?php if(array_key_exists('liftgate_required', $carrierGroup) && $carrierGroup['liftgate_required'] === '1'): ?>
                     <?php echo __('Liftgate required'); ?>
                     <br/>
                 <?php endif; ?>
-                <?php if($carrierGroup['inside_delivery'] === '1'): ?>
+                <?php if(array_key_exists('inside_delivery', $carrierGroup) && $carrierGroup['inside_delivery'] === '1'): ?>
                     <?php echo __('Inside Delivery'); ?>
                     <br/>
                 <?php endif; ?>
-                <?php if($carrierGroup['limited_delivery'] === '1'): ?>
+                <?php if(array_key_exists('limited_delivery', $carrierGroup) && $carrierGroup['limited_delivery'] === '1'): ?>
                     <?php echo __('Limited Access Delivery'); ?>
                     <br/>
                 <?php endif; ?>
-                <?php if($carrierGroup['notify_required'] === '1'): ?>
+                <?php if(array_key_exists('notify_required', $carrierGroup) && $carrierGroup['notify_required'] === '1'): ?>
                     <?php echo __('Scheduled Appointment'); ?>
                     <br/>
                 <?php endif; ?>
-                    <?php if($carrierGroup['customer_carrier'] != ''): ?>
-                            <?php echo __('Customer Carrier') .': ' .$block->escapeHtml($carrierGroup['customer_carrier']) ?>
-                            <br/>
-                    <?php endif; ?>
-                    <?php if($carrierGroup['customer_carrier_ph'] != ''): ?>
-                            <?php echo __('Carrier Phone') .': ' .$block->escapeHtml($carrierGroup['customer_carrier_ph']) ?>
-                            <br/>
-                    <?php endif; ?>
-                    <?php if($carrierGroup['customer_carrier_account'] != ''): ?>
-                            <?php echo __('Carrier Account') .': ' .$block->escapeHtml($carrierGroup['customer_carrier_account']) ?>
-                            <br/>
-                    <?php endif; ?>
             </div>
         <?php endforeach; ?>
     </div>

--- a/src/view/adminhtml/templates/order/view/shq_info.phtml
+++ b/src/view/adminhtml/templates/order/view/shq_info.phtml
@@ -63,6 +63,18 @@
                     <?php echo __('Scheduled Appointment'); ?>
                     <br/>
                 <?php endif; ?>
+                <?php if(array_key_exists('customer_carrier', $carrierGroup) && $carrierGroup['customer_carrier'] != ''): ?>
+                    <?php echo __('Customer Carrier') .': ' .$block->escapeHtml($carrierGroup['customer_carrier']) ?>
+                    <br/>
+                <?php endif; ?>
+                <?php if(array_key_exists('customer_carrier_ph', $carrierGroup) && $carrierGroup['customer_carrier_ph'] != ''): ?>
+                    <?php echo __('Carrier Phone') .': ' .$block->escapeHtml($carrierGroup['customer_carrier_ph']) ?>
+                    <br/>
+                <?php endif; ?>
+                <?php if(array_key_exists('customer_carrier_account', $carrierGroup) && $carrierGroup['customer_carrier_account'] != ''): ?>
+                    <?php echo __('Carrier Account') .': ' .$block->escapeHtml($carrierGroup['customer_carrier_account']) ?>
+                    <br/>
+                <?php endif; ?>
             </div>
         <?php endforeach; ?>
     </div>


### PR DESCRIPTION
…there and keeping the admin from viewing an order if that happens.

This occurs when there is data migrated from Magento 1's version of ShipperHQ, and you try to view the order in the admin, you get a stack trace due to some missing data in the Carrier Group information. This silently ignores that and keeps the admin's order screen working.