### PR TITLE
Add missing shipping detail argument.

### DIFF
--- a/src/Block/Adminhtml/Order/View/Info.php
+++ b/src/Block/Adminhtml/Order/View/Info.php
@@ -107,7 +107,7 @@ class Info extends AbstractOrder
                 //legacy
                 if($order->getCarriergroupShippingDetails() != '') {
                     $this->cgInfo = $this->shipperDataHelper->decodeShippingDetails(
-
+                        $order->getCarriergroupShippingDetails()
                     );
                 } else {
                     //if we have no information, check for flag if we've checked already


### PR DESCRIPTION
Caused an error when loading the order detail page for an order created in Magento 1.