### PR TITLE
Updated shipping address renderer template with core Magento changes

### DIFF
--- a/src/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/src/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -8,15 +8,15 @@
   ~ @author ShipperHQ Team sales@shipperhq.com
   -->
 
-<div class="shipping-address-item" data-bind="css: isSelected() ? 'selected-item' : 'not-selected-item'">
-    <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko -->
-    <!-- ko text: address().lastname --><!-- /ko --> <!-- ko text: address().suffix --><!-- /ko --><br/>
-    <!-- ko text: address().street --><!-- /ko --><br/>
-    <!-- ko text: address().city --><!-- /ko -->, <!-- ko text: address().region --><!-- /ko -->
-    <!-- ko text: address().postcode --><!-- /ko --><br/>
-    <!-- ko text: getCountryName(address().countryId) --><!-- /ko --><br/>
-    <!-- ko text: address().telephone --><!-- /ko --><br/>
-    <!-- ko foreach: { data: address().customAttributes, as: 'element' } -->
+<div class="shipping-address-item" css="'selected-item' : isSelected() , 'not-selected-item':!isSelected()">
+    <text args="address().prefix"/> <text args="address().firstname"/> <text args="address().middlename"/>
+    <text args="address().lastname"/> <text args="address().suffix"/><br/>
+    <text args="_.values(address().street).join(', ')"/><br/>
+    <text args="address().city "/>, <span text="address().region"></span> <text args="address().postcode"/><br/>
+    <text args="getCountryName(address().countryId)"/><br/>
+    <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br/>
+
+    <each args="data: address().customAttributes, as: 'element'">
         <!-- ko if: element.attribute_code != 'destination_type' && element.attribute_code != 'validation_status' -->
             <!-- ko if: element.value != null -->
                 <!-- ko text: element.value --><!-- /ko --><br/>
@@ -25,15 +25,16 @@
                 <!-- ko text: element.attribute_code --><!-- /ko --><br/>
             <!-- /ko -->
         <!-- /ko -->
-    <!-- /ko -->
-    <!-- ko if: (address().isEditable()) -->
-    <button type="button"
+    </each>
+
+    <button visible="address().isEditable()" type="button"
             class="action edit-address-link"
-            data-bind="click: editAddress, visible: address().isEditable()">
-        <span data-bind="i18n: 'Edit'"></span>
+            click="editAddress">
+        <span translate="'Edit'"></span>
+    </button>
+    <!-- ko if: (!isSelected()) -->
+    <button type="button" click="selectAddress" class="action action-select-shipping-item">
+        <span translate="'Ship Here'"></span>
     </button>
     <!-- /ko -->
-    <button type="button" data-bind="click: selectAddress" class="action action-select-shipping-item">
-        <span data-bind="i18n: 'Ship Here'"></span>
-    </button>
 </div>


### PR DESCRIPTION
It looks like the template was copied back when Magento 2.1 was the latest version.

With this PR I've brought across the changes done since, but kept the customisations in place (destination_type and validation_status checks).

The template changes are from Magento 2.4.1, but the template still looks pretty similar to the Magento 2.2.7+ versions.

This PR fixes https://github.com/shipperhq/module-shipper/issues/87