### PR TITLE
replicated a magento patch see details here https://support.magento.c…

### DIFF
--- a/src/view/frontend/web/template/billing-address/details.html
+++ b/src/view/frontend/web/template/billing-address/details.html
@@ -11,7 +11,7 @@
 <div if="isAddressDetailsVisible() && currentBillingAddress()" class="billing-address-details">
     <text args="currentBillingAddress().prefix"/> <text args="currentBillingAddress().firstname"/> <text args="currentBillingAddress().middlename"/>
     <text args="currentBillingAddress().lastname"/> <text args="currentBillingAddress().suffix"/><br/>
-    <text args="_.values(currentBillingAddress().street).join(', ')"/><br/>
+    <text args="(currentBillingAddress().street).join(', ')"/><br/>
     <text args="currentBillingAddress().city "/>, <span text="currentBillingAddress().region"></span> <text args="currentBillingAddress().postcode"/><br/>
     <text args="getCountryName(currentBillingAddress().countryId)"/><br/>
     <a if="currentBillingAddress().telephone" attr="'href': 'tel:' + currentBillingAddress().telephone" text="currentBillingAddress().telephone"></a><br/>


### PR DESCRIPTION
replicated a magento patch see details here https://support.magento.com/hc/en-us/articles/360058863531-MDVA-33289-Magento-patch-Javascript-in-address-at-checkout without this I get javascript displayed after the street address on the payment part of the checkout (using braintree) the link is to the magento patch for this, this change stops the patch being overwritten. Im not sure if this is needed on the shipping-information file as well, but i dont seem to get any issues without it.

I dont know if this will be usefull for anyone else, or if it should be merged in, but if you could look it over and see if its usefull

cheers