### PR TITLE
order.loadShippingRates() Csp bug at latest magento 2.4.7

### DIFF
--- a/src/view/adminhtml/templates/order/create/shipping/method/form.phtml
+++ b/src/view/adminhtml/templates/order/create/shipping/method/form.phtml
@@ -128,10 +128,11 @@
     <?php endif; ?>
 <?php else: ?>
     <div id="order-shipping-method-summary" class="order-shipping-method-summary">
-        <a href="#" onclick="order.loadShippingRates();return false" class="action-default">
+        <a href="#" id="loadShippingRates" class="action-default">
             <span><?php /* @escapeNotVerified */
-                echo __('Get shipping methods and rates') ?></span>
+            echo __('Get shipping methods and rates') ?></span>
         </a>
+        <?= $secureRenderer->renderEventListenerAsTag('onclick', 'order.loadShippingRates();return false;', '#loadShippingRates'); ?>
         <input type="hidden" name="order[has_shipping]" value="" class="required-entry"/>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
Source https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/payments/admin-create-order-page-in-csp-restricted-mode