### PR TITLE
Cast carrier & method title of a shipping rate to a string, so it's n…

### DIFF
--- a/src/Model/Carrier/Shipper.php
+++ b/src/Model/Carrier/Shipper.php
@@ -630,7 +630,7 @@ class Shipper extends AbstractCarrier implements CarrierInterface
                     $rate->setCarrier($carrierRate['code']);
                     $lengthCarrierCode = strlen((string) $carrierRate['code']);
 
-                    $rate->setCarrierTitle(__($carrierRate['title']));
+                    $rate->setCarrierTitle((string) __($carrierRate['title']));
 
                     $methodCombineCode = preg_replace('/&|;| /', "", (string) $rateDetails['methodcode']);
                     //SHQ16-1520 - enforce limit on length of shipping carrier code
@@ -643,7 +643,7 @@ class Shipper extends AbstractCarrier implements CarrierInterface
                         $methodCombineCode = substr($methodCombineCode, $trim, $lengthMethodCode);
                     }
 
-                    $rate->setMethodTitle(__($rateDetails['method_title']));
+                    $rate->setMethodTitle((string) __($rateDetails['method_title']));
                     $rate->setMethod($methodCombineCode);
                     $tooltip = "";
                     if (isset($rateDetails['tooltip']) && !empty($rateDetails['tooltip'])) {


### PR DESCRIPTION
…ot an unexpected Phrase object.


If these aren't of type `string` they give issues with Hyvä Checkout version 1.3.15
Because over there they expect these to be of type `string` otherwise you get errors like this:
```
TypeError: Hyva\Checkout\ViewModel\Checkout\Shipping\MethodList::getMethodTitle(): Return value must be of type string, Magento\Framework\Phrase returned in vendor/hyva-themes/magento2-hyva-checkout/src/ViewModel/Checkout/Shipping/MethodList.php:147
```

The Hyvä Checkout code that's responsible for this error is like this (I adapted it to be a bit more readable):
```php
    public function getMethodTitle(ShippingMethodInterface $method): string
    {
        $methodTitle  = $method->getMethodTitle();

        // some checks and conditions that aren't relevant in scope of this bugreport

        return $methodTitle;
    }
```